### PR TITLE
Add picture of main room to landing page on mobile

### DIFF
--- a/css/index.sass
+++ b/css/index.sass
@@ -111,6 +111,8 @@ iframe
   position: absolute
   bottom: 0
   padding: 1.1em 1.4em 1.3em
+  img
+    display: none
 
 article
   padding: 2em
@@ -129,6 +131,10 @@ article
     p
       padding: 30px 10px 10px
       line-height: 1.7
+    img
+      display: block
+      width: 100%
+      height: 100%
   article
     margin-top: auto
     padding-top: 0

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@ scripts:
 <div class="jumbotron">
     <h1>Engage. Enjoy. Thrive.</h1>
     <p>We take a distinctive approach to English language study. Our students benefit from personalized instruction in unusually small classes. Our group classes enroll a <u>maximum</u> of six students, and many classes are even smaller. Learn more about our school in <a href="welcome/english">English</a>, <a href="welcome/spanish">Español</a>, <a href="welcome/arabic">العربية</a>, <a href="welcome/chinese">中文</a>, <a href="welcome/french">Français</a>, <a href="welcome/german">Deutsche</a>, <a href="welcome/indonesian">Bahasa Indonesia</a>, <a href="welcome/italian">Italiano</a>, <a href="welcome/japanese">日本語</a>, <a href="welcome/korean">한국어</a>, <a href="welcome/persian">فارسی</a>, <a href="welcome/portuguese">Português</a>, <a href="welcome/russian">Русский</a>, <a href="welcome/turkish">Türk</a>, <a href="welcome/amharic">አማርኛ</a>, or <a href="welcome/mongolian">монгол хэл</a>; and contact us and tell us more about your language education needs and interests. We look forward to meeting you!</p>
+    <img src="/images/main_room.jpg">
 </div>
 <article>
     <p>Serving the Washington, D.C. area international community since 1991, English Now! offers English language courses for students of all levels. Our school is conveniently located close to the Bethesda Metro, and we also offer classes offsite at embassies as well as at students’ homes or offices.</p>


### PR DESCRIPTION
Add picture (/images/main_room.jpg) below the text in the jumbotron on the mobile site. Displays only if the width of the screen is 800px or lower.