### PR TITLE
Add languages for community service page

### DIFF
--- a/community-service.html
+++ b/community-service.html
@@ -6,6 +6,7 @@ stylesheets:
 ---
 <article>
     <h1>Community Service and Volunteering</h1>
+    <p class="heading"><a href="community-service/japanese">日本語</a> | <a href="community-service/spanish">Español</a></p>
     <img src="images/food-packing-community-service.jpg">
     <p>English Now! and our community service partner, the Washington Center for International Education (WCIE), organize volunteer activities year-round.</p>
     <p>Our goals are to connect the Washington, D.C. international community to the local community, and to help others. We hope you can join us!</p>

--- a/community-service.html
+++ b/community-service.html
@@ -6,8 +6,8 @@ stylesheets:
 ---
 <article>
     <h1>Community Service and Volunteering</h1>
-    <p class="heading"><a href="community-service/japanese">日本語</a> | <a href="community-service/spanish">Español</a></p>
-    <img src="images/food-packing-community-service.jpg">
+    <p class="heading"><a href="/community-service/japanese">日本語</a> | <a href="/community-service/spanish">Español</a></p>
+    <img src="/images/food-packing-community-service.jpg">
     <p>English Now! and our community service partner, the Washington Center for International Education (WCIE), organize volunteer activities year-round.</p>
     <p>Our goals are to connect the Washington, D.C. international community to the local community, and to help others. We hope you can join us!</p>
     <p><strong>Community Service for Adults.</strong> English Now! and WCIE encourage international residents of the Washington, D.C. area to consider volunteering. Volunteering offers an opportunity to speak English outside the classroom, meet people, and engage across cultures.</p>

--- a/community-service/japanese.html
+++ b/community-service/japanese.html
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Community Service
+stylesheets:
+- community-service
+---
+<article>
+    <h1>Community Service and Volunteering</h1>
+    <p>English Now! and our community service partner, the Washington Center for International Education (WCIE), organize volunteer activities year-round.</p>
+    <p>Our goals are to connect the Washington, D.C. international community to the local community, and to help others. We hope you can join us!</p>
+    <p><strong>Community Service for Adults.</strong> English Now! and WCIE encourage international residents of the Washington, D.C. area to consider volunteering. Volunteering offers an opportunity to speak English outside the classroom, meet people, and engage across cultures.</p>
+    <p><strong>Student Service Learning (SSL) for International Teens.</strong> WCIE also organizes programs that enable international teens to earn SSL service hours. SSL service hours are required for high school graduation in State of Maryland public schools and are encouraged in many private schools. For information about WCIE's SSL programs, see <a target="_blank" href="files/WCIE - Student Service Learning Programs for International Teens.pdf">here</a>.</p>
+    <p><strong>Community Service Weeks.</strong> For the last five years, we have offered two Community Service Weeks a year, in the spring and fall. Community Service Weeks offer many options to participate in small group community service activities. For a typical schedule of activities&mdash;for our Fall 2019 Community Service Week&mdash;see <a target="_blank" href="files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">here</a>.</p>
+    <br>
+    <h2 class="heading">NOW &mdash; FOR SPRING 2020 &mdash; COMMUNITY SERVICE MONTH</h2>
+    <br>
+    <p>In Spring 2020, the world is confronting a global pandemic. Many people are suffering, and English Now! and WCIE are responding with more than just a Community Service Week&mdash;we are organizing a Community Service <u>Month</u>.</p>
+    <p>Community Service Month focuses immediately on basic needs&mdash;food security. Many in our community may not have enough food, as the economic impact of the public health crisis hits.</p>
+    <p>Please consider participating in our <strong><q>Online Food Drive</q></strong>. Help by ordering online grocery deliveries to one of two great organizations. This food will go directly to people in need, in the community, through these organizations.</p>
+    <img src="images/bethesdacares.png">
+    <p><a href="http://bethesdacares.org/">Bethesda Cares</a> is a great, local organization that serves the homeless in Bethesda and Montgomery County. Bethesda Cares <u>urgently</u> needs food to feed the homeless. Click on any of the links below to order food. Have orders shipped to Bethesda Cares: Maria Garcia Ripa, Operations Director, Bethesda Cares, 7728 Woodmont Avenue, Bethesda, MD 20814.</p>
+    <ul>
+        <li><a target="_blank" href="https://www.amazon.com/gp/offer-listing/B00AFDB9XO/ref=dp_olp_new_mbc?ie=UTF8&condition=new" rel="noopener">Vienna Sausage</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/Kirkland-Signature-Expect-Trail-Snack/dp/B07JQV44GS/ref=sr_1_5?dchild=1&keywords=trail+mix+packets+bulk&qid=1584745843&sr=8-5" rel="noopener">Trail mix</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/AmazonBasics-Compostable-Clamshell-3-Compartment-Containers/dp/B07GYL3672/ref=sr_1_9?keywords=styrofoam+carry+out&amp;qid=1584362087&amp;s=grocery&amp;sr=1-9-catcorr" rel="noopener">Carry-out trays</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/Lipton-Soup-Chicken-Noodle-22-count/dp/B000JCTX5W" rel="noopener">Noodle Soup</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/Ultimate-Healthy-Fitness-Box-Protein/dp/B077R1B7LV/ref=sr_1_17?crid=MAK6DTJYRDGS&amp;dchild=1&amp;keywords=granola+bars+bulk&amp;qid=1584726539&amp;sprefix=granola+bars%2Caps%2C141&amp;sr=8-17" rel="noopener">Granola bars</a></li>
+    </ul>
+    <p><a href="https://septemberhousemaj.org/">September House MAJ</a> is another great organization and is a long-term English Now!/WCIE partner. September House MAJ provides support for everyday life for Japanese people living in the Mid-Atlantic region. The organization helps families overcome financial, social, and emotional hardship by providing them with consultations in Japanese, including assistance accessing appropriate public resources, and also including food assistance during this crisis.</p>
+    <p>September House MAJ has an Amazon Wish list that enables you to donate Japanese food to families in need. Click here:</p>
+    <p><a href="https://www.amazon.com/hz/wishlist/ls/1ZJA4TNX9M2KF?ref_=wl_share">https://www.amazon.com/hz/wishlist/ls/1ZJA4TNX9M2KF?ref_=wl_share</a></p>
+    <p>If you purchase food on this list, Amazon will send it automatically to September House MAJ.</p>
+    <p><strong>Additional Community Service Month Programs.</strong> We are only starting to feel the impact of the global pandemic. We will do much more to serve the community, and we need your help.</p>
+    <p>Please provide us your name and email address in the form below. We will email you about additional programs to serve the community and bring us together.</p>
+    <p>Thank you very much for your interest in community service. We look forward to serving the community together with you!</p>
+    <iframe id="form" src="https://docs.google.com/forms/d/e/1FAIpQLSc57hU90OEADrj5JYTOKhzGaHr1K1LnTRFXwhJ0pKswEXMd0w/viewform?embedded=true" width="100%" height="729" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+    <img src="images/food-packing-community-service.jpg">
+</article>

--- a/community-service/japanese.html
+++ b/community-service/japanese.html
@@ -6,20 +6,20 @@ stylesheets:
 ---
 <article>
     <h1>Community Service and Volunteering</h1>
-    <p class="heading"><a href="community-service">English</a></p>
-    <img src="images/food-packing-community-service.jpg">
+    <p class="heading"><a href="/community-service">English</a></p>
+    <img src="/images/food-packing-community-service.jpg">
     <p>English Now！とコミュニティサービスパートナーであるワシントン国際教育センター（WCIE）は、年間を通してボランティア活動を企画しています。</p>
     <p>私たちの目標は、ワシントンD.C.の国際社会と地域社会を結びつけ、人々を支援することです。ぜひ皆さんもご参加ください！</p>
     <p><strong>コミュニティサービス</strong> English Now！とWCIEは、ワシントンD.C.地域の外国人居住者の方々にボランティア活動に参加できる機会を提供しています。ボランティア活動では、現地の人々と出会い、英語で話し文化を超えて交流することができます。</p>
-    <p><strong>中・高校生の学生ボランティア学習（SSL)</strong> WCIEは中・高校生がSSLクレジットを得られるようにするプログラムを提供しています。 SSL credit hoursは、メリーランド州の公立学校での高校卒業には必須であり、多くの私立学校でも推奨されています。 WCIEのSSLプログラムについては、こちらをご覧ください。<a target="_blank" href="files/WCIE - Student Service Learning Programs for International Teens.pdf">here</a>.</p>
-    <p><strong>コミュニティサービスウィーク</strong> 私たちは過去5年間、毎年、春と秋の2回、コミュニティサービスウィークを開催しています。コミュニティサービスウィークでは、色々な種類のボランティア活動を行っています。 2019年秋のコミュニティサービスウィークの活動のスケジュールについては、こちらをご覧ください。<a target="_blank" href="files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">here</a>.</p>
+    <p><strong>中・高校生の学生ボランティア学習（SSL)</strong> WCIEは中・高校生がSSLクレジットを得られるようにするプログラムを提供しています。 SSL credit hoursは、メリーランド州の公立学校での高校卒業には必須であり、多くの私立学校でも推奨されています。 WCIEのSSLプログラムについては、<a target="_blank" href="/files/WCIE - Student Service Learning Programs for International Teens.pdf">こちらをご覧ください</a>。</p>
+    <p><strong>コミュニティサービスウィーク</strong> 私たちは過去5年間、毎年、春と秋の2回、コミュニティサービスウィークを開催しています。コミュニティサービスウィークでは、色々な種類のボランティア活動を行っています。 2019年秋のコミュニティサービスウィークの活動のスケジュールについては、<a target="_blank" href="/files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">こちらをご覧ください</a>。</p>
     <br>
     <h2 class="heading">2020年春　コミュニティサービス月間</h2>
     <br>
     <p>2020年春、世の中は今、世界的な困難に直面しており多くの人々が苦しんでいます。そこでEnglish Now!ではコミュニティサービスウィークではなく、コミュニティサービス月間を開催しています。</p>
     <p>コミュニティサービス月間では、まず基本的なニーズである食料支援に焦点を当てています。地域社会の多くの人々は、今回の騒動による経済的な影響で十分な食料が無くなっていくと考えられます。</p>
     <p>この機会にぜひ「オンラインフードドライブ」への参加をご検討ください。私たちは2つの組織と提携しています。 これはインターネットを使って食料品の寄付ができます。オンラインで商品を購入しますと、これらの組織を介して、コミュニティ内の困っている人々に食糧などを直接届けれます。</p>
-    <img src="images/bethesdacares.png">
+    <img src="/images/bethesdacares.png">
     <p><a href="http://bethesdacares.org/">Bethesda Cares</a> は、ベセスダとモンゴメリーカウンティのホームレスにサービスを提供する素晴らしい地元の組織です。Bethesda Caresは、ホームレスの人々の為に食糧を緊急に必要としています。下記のリストをクリックして下さい。購入された商品はBethesda Caresに自動的に発送されます Bethesda Cares: Maria Garcia Ripa, Operations Director, Bethesda Cares, 7728 Woodmont Avenue, Bethesda, MD 20814.</p>
     <ul>
         <li><a target="_blank" href="https://www.amazon.com/gp/offer-listing/B00AFDB9XO/ref=dp_olp_new_mbc?ie=UTF8&condition=new" rel="noopener">Vienna Sausage</a></li>

--- a/community-service/japanese.html
+++ b/community-service/japanese.html
@@ -6,19 +6,21 @@ stylesheets:
 ---
 <article>
     <h1>Community Service and Volunteering</h1>
-    <p>English Now! and our community service partner, the Washington Center for International Education (WCIE), organize volunteer activities year-round.</p>
-    <p>Our goals are to connect the Washington, D.C. international community to the local community, and to help others. We hope you can join us!</p>
-    <p><strong>Community Service for Adults.</strong> English Now! and WCIE encourage international residents of the Washington, D.C. area to consider volunteering. Volunteering offers an opportunity to speak English outside the classroom, meet people, and engage across cultures.</p>
-    <p><strong>Student Service Learning (SSL) for International Teens.</strong> WCIE also organizes programs that enable international teens to earn SSL service hours. SSL service hours are required for high school graduation in State of Maryland public schools and are encouraged in many private schools. For information about WCIE's SSL programs, see <a target="_blank" href="files/WCIE - Student Service Learning Programs for International Teens.pdf">here</a>.</p>
-    <p><strong>Community Service Weeks.</strong> For the last five years, we have offered two Community Service Weeks a year, in the spring and fall. Community Service Weeks offer many options to participate in small group community service activities. For a typical schedule of activities&mdash;for our Fall 2019 Community Service Week&mdash;see <a target="_blank" href="files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">here</a>.</p>
+    <p class="heading"><a href="community-service">English</a></p>
+    <img src="images/food-packing-community-service.jpg">
+    <p>English Now！とコミュニティサービスパートナーであるワシントン国際教育センター（WCIE）は、年間を通してボランティア活動を企画しています。</p>
+    <p>私たちの目標は、ワシントンD.C.の国際社会と地域社会を結びつけ、人々を支援することです。ぜひ皆さんもご参加ください！</p>
+    <p><strong>コミュニティサービス</strong> English Now！とWCIEは、ワシントンD.C.地域の外国人居住者の方々にボランティア活動に参加できる機会を提供しています。ボランティア活動では、現地の人々と出会い、英語で話し文化を超えて交流することができます。</p>
+    <p><strong>中・高校生の学生ボランティア学習（SSL)</strong> WCIEは中・高校生がSSLクレジットを得られるようにするプログラムを提供しています。 SSL credit hoursは、メリーランド州の公立学校での高校卒業には必須であり、多くの私立学校でも推奨されています。 WCIEのSSLプログラムについては、こちらをご覧ください。<a target="_blank" href="files/WCIE - Student Service Learning Programs for International Teens.pdf">here</a>.</p>
+    <p><strong>コミュニティサービスウィーク</strong> 私たちは過去5年間、毎年、春と秋の2回、コミュニティサービスウィークを開催しています。コミュニティサービスウィークでは、色々な種類のボランティア活動を行っています。 2019年秋のコミュニティサービスウィークの活動のスケジュールについては、こちらをご覧ください。<a target="_blank" href="files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">here</a>.</p>
     <br>
-    <h2 class="heading">NOW &mdash; FOR SPRING 2020 &mdash; COMMUNITY SERVICE MONTH</h2>
+    <h2 class="heading">2020年春　コミュニティサービス月間</h2>
     <br>
-    <p>In Spring 2020, the world is confronting a global pandemic. Many people are suffering, and English Now! and WCIE are responding with more than just a Community Service Week&mdash;we are organizing a Community Service <u>Month</u>.</p>
-    <p>Community Service Month focuses immediately on basic needs&mdash;food security. Many in our community may not have enough food, as the economic impact of the public health crisis hits.</p>
-    <p>Please consider participating in our <strong><q>Online Food Drive</q></strong>. Help by ordering online grocery deliveries to one of two great organizations. This food will go directly to people in need, in the community, through these organizations.</p>
+    <p>2020年春、世の中は今、世界的な困難に直面しており多くの人々が苦しんでいます。そこでEnglish Now!ではコミュニティサービスウィークではなく、コミュニティサービス月間を開催しています。</p>
+    <p>コミュニティサービス月間では、まず基本的なニーズである食料支援に焦点を当てています。地域社会の多くの人々は、今回の騒動による経済的な影響で十分な食料が無くなっていくと考えられます。</p>
+    <p>この機会にぜひ「オンラインフードドライブ」への参加をご検討ください。私たちは2つの組織と提携しています。 これはインターネットを使って食料品の寄付ができます。オンラインで商品を購入しますと、これらの組織を介して、コミュニティ内の困っている人々に食糧などを直接届けれます。</p>
     <img src="images/bethesdacares.png">
-    <p><a href="http://bethesdacares.org/">Bethesda Cares</a> is a great, local organization that serves the homeless in Bethesda and Montgomery County. Bethesda Cares <u>urgently</u> needs food to feed the homeless. Click on any of the links below to order food. Have orders shipped to Bethesda Cares: Maria Garcia Ripa, Operations Director, Bethesda Cares, 7728 Woodmont Avenue, Bethesda, MD 20814.</p>
+    <p><a href="http://bethesdacares.org/">Bethesda Cares</a> は、ベセスダとモンゴメリーカウンティのホームレスにサービスを提供する素晴らしい地元の組織です。Bethesda Caresは、ホームレスの人々の為に食糧を緊急に必要としています。下記のリストをクリックして下さい。購入された商品はBethesda Caresに自動的に発送されます Bethesda Cares: Maria Garcia Ripa, Operations Director, Bethesda Cares, 7728 Woodmont Avenue, Bethesda, MD 20814.</p>
     <ul>
         <li><a target="_blank" href="https://www.amazon.com/gp/offer-listing/B00AFDB9XO/ref=dp_olp_new_mbc?ie=UTF8&condition=new" rel="noopener">Vienna Sausage</a></li>
         <li><a target="_blank" href="https://www.amazon.com/Kirkland-Signature-Expect-Trail-Snack/dp/B07JQV44GS/ref=sr_1_5?dchild=1&keywords=trail+mix+packets+bulk&qid=1584745843&sr=8-5" rel="noopener">Trail mix</a></li>
@@ -26,13 +28,12 @@ stylesheets:
         <li><a target="_blank" href="https://www.amazon.com/Lipton-Soup-Chicken-Noodle-22-count/dp/B000JCTX5W" rel="noopener">Noodle Soup</a></li>
         <li><a target="_blank" href="https://www.amazon.com/Ultimate-Healthy-Fitness-Box-Protein/dp/B077R1B7LV/ref=sr_1_17?crid=MAK6DTJYRDGS&amp;dchild=1&amp;keywords=granola+bars+bulk&amp;qid=1584726539&amp;sprefix=granola+bars%2Caps%2C141&amp;sr=8-17" rel="noopener">Granola bars</a></li>
     </ul>
-    <p><a href="https://septemberhousemaj.org/">September House MAJ</a> is another great organization and is a long-term English Now!/WCIE partner. September House MAJ provides support for everyday life for Japanese people living in the Mid-Atlantic region. The organization helps families overcome financial, social, and emotional hardship by providing them with consultations in Japanese, including assistance accessing appropriate public resources, and also including food assistance during this crisis.</p>
-    <p>September House MAJ has an Amazon Wish list that enables you to donate Japanese food to families in need. Click here:</p>
+    <p><a href="https://septemberhousemaj.org/">September House MAJ</a> は、素晴らしい組織であり、長期的なEnglish Now！とWCIEのパートナーです。</p>
+    <p>September House MAJでは、困っている日本人家族に日本食を寄付できるAmazon Wishリストがあります。こちらをクリック：</p>
     <p><a href="https://www.amazon.com/hz/wishlist/ls/1ZJA4TNX9M2KF?ref_=wl_share">https://www.amazon.com/hz/wishlist/ls/1ZJA4TNX9M2KF?ref_=wl_share</a></p>
-    <p>If you purchase food on this list, Amazon will send it automatically to September House MAJ.</p>
-    <p><strong>Additional Community Service Month Programs.</strong> We are only starting to feel the impact of the global pandemic. We will do much more to serve the community, and we need your help.</p>
-    <p>Please provide us your name and email address in the form below. We will email you about additional programs to serve the community and bring us together.</p>
-    <p>Thank you very much for your interest in community service. We look forward to serving the community together with you!</p>
+    <p>このリストから食品を購入すると、Amazonから自動的にSeptember House MAJへ送信します。</p>
+    <p><strong>コミュニティサービス月間プログラム。</strong> 私たちは世界的なパンデミックの影響を感じ始めたところです。私たちはコミュニティに貢献するためにもっと多くのことをしていきたいと考えています。そしてあなたの助けが必要です。</p>
+    <p>このページの右上隅に名前とメールアドレスを入力してください。コミュニティサービスを提供するための追加プログラムについてメールでお知らせします。</p>
+    <p>コミュニティサービスに関心をお寄せいただき、ありがとうございます。私たちは、あなたと一緒にコミュニティに貢献することを楽しみにしています！</p>
     <iframe id="form" src="https://docs.google.com/forms/d/e/1FAIpQLSc57hU90OEADrj5JYTOKhzGaHr1K1LnTRFXwhJ0pKswEXMd0w/viewform?embedded=true" width="100%" height="729" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-    <img src="images/food-packing-community-service.jpg">
 </article>

--- a/community-service/japanese.html
+++ b/community-service/japanese.html
@@ -5,7 +5,7 @@ stylesheets:
 - community-service
 ---
 <article>
-    <h1>Community Service and Volunteering</h1>
+    <h1>「コミュニティーサービスとボランティア」</h1>
     <p class="heading"><a href="/community-service">English</a></p>
     <img src="/images/food-packing-community-service.jpg">
     <p>English Now！とコミュニティサービスパートナーであるワシントン国際教育センター（WCIE）は、年間を通してボランティア活動を企画しています。</p>

--- a/community-service/spanish.html
+++ b/community-service/spanish.html
@@ -6,6 +6,8 @@ stylesheets:
 ---
 <article>
     <h1>Un Apoyo y Voluntarismo a Servicio de la Comunidad</h1>
+    <p class="heading"><a href="community-service">English</a></p>
+    <img src="images/food-packing-community-service.jpg">
     <p>English Now! con nuestro socio, el Centro de Educación Internacional de Washington (CEIW) organizamos actividades para voluntarios durante todo el año.</p>
     <p>Nuestra meta es unir la comunidad internacional de Washington D.C. con el propósito de proporcionar ayuda a las personas necesitadas. Les invitamos a formar parte de esta misión.</p>
     <p><strong>Un Servicio Comunitario para Adultos</strong> English Now! y el Centro de Educación promocionamos el voluntarismo entre nuestros residentes internacionales de la área. Esta oportunidad les ofrece la  practica de inglés fuera del salon, el conocimiento de gente nueva, y el intercambio de culturas.</p>
@@ -33,5 +35,4 @@ stylesheets:
     <p>Please provide us your name and email address in the form below. We will email you about additional programs to serve the community and bring us together.</p>
     <p>Thank you very much for your interest in community service. We look forward to serving the community together with you!</p>
     <iframe id="form" src="https://docs.google.com/forms/d/e/1FAIpQLSc57hU90OEADrj5JYTOKhzGaHr1K1LnTRFXwhJ0pKswEXMd0w/viewform?embedded=true" width="100%" height="729" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-    <img src="images/food-packing-community-service.jpg">
 </article>

--- a/community-service/spanish.html
+++ b/community-service/spanish.html
@@ -6,19 +6,19 @@ stylesheets:
 ---
 <article>
     <h1>Un Apoyo y Voluntarismo a Servicio de la Comunidad</h1>
-    <p class="heading"><a href="community-service">English</a></p>
-    <img src="images/food-packing-community-service.jpg">
+    <p class="heading"><a href="/community-service">English</a></p>
+    <img src="/images/food-packing-community-service.jpg">
     <p>English Now! con nuestro socio, el Centro de Educación Internacional de Washington (CEIW) organizamos actividades para voluntarios durante todo el año.</p>
     <p>Nuestra meta es unir la comunidad internacional de Washington D.C. con el propósito de proporcionar ayuda a las personas necesitadas. Les invitamos a formar parte de esta misión.</p>
     <p><strong>Un Servicio Comunitario para Adultos</strong> English Now! y el Centro de Educación promocionamos el voluntarismo entre nuestros residentes internacionales de la área. Esta oportunidad les ofrece la  practica de inglés fuera del salon, el conocimiento de gente nueva, y el intercambio de culturas.</p>
-    <p><strong>Servicios Estudiantiles de Aprendisaje para Adolescents Internacionales</strong> Nuestro Centro de Educación organiza programas que facilitan trabajar las horas de servicio comunitario (“Student Service Learning”, or SSL) requerido por las escuelas públicas y privadas.  Para graduarse del “High School” es necesario cumplir este requisíto. Para conseguir más información sobre los programas de Nuestro Centro en Wahington, véase <a target="_blank" href="files/WCIE - Student Service Learning Programs for International Teens.pdf">aquí</a>.</p>
-    <p><strong>Semanas de Servicios Comunitarios</strong> En el curso de los últimos cinco años hemos organizado dos semanas de servicio comunitario en cada año: una en la primavera y otra en el otoño.  Estas semanas proporcionan oportunidades para participar en actividades de servicio comunitario en pequeños grupos.  Para ver nuestro calendario de actividades del año pasado, véase <a target="_blank" href="files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">aquí</a>.</p>
+    <p><strong>Servicios Estudiantiles de Aprendisaje para Adolescents Internacionales</strong> Nuestro Centro de Educación organiza programas que facilitan trabajar las horas de servicio comunitario (“Student Service Learning”, or SSL) requerido por las escuelas públicas y privadas.  Para graduarse del “High School” es necesario cumplir este requisíto. Para conseguir más información sobre los programas de Nuestro Centro en Wahington, véase <a target="_blank" href="/files/WCIE - Student Service Learning Programs for International Teens.pdf">aquí</a>.</p>
+    <p><strong>Semanas de Servicios Comunitarios</strong> En el curso de los últimos cinco años hemos organizado dos semanas de servicio comunitario en cada año: una en la primavera y otra en el otoño.  Estas semanas proporcionan oportunidades para participar en actividades de servicio comunitario en pequeños grupos.  Para ver nuestro calendario de actividades del año pasado, véase <a target="_blank" href="/files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">aquí</a>.</p>
     <br>
     <h2 class="heading">Esta primavera de 2020 será el mes del servicio comunitario</h2>
     <br>
     <p>En este momento histórico enfrentamos una pandemia global. Muchas personas estan sufriendo este acontecimiento con muchas necesidades y escasez. Estamos organizando un plan de servicio alimentaria y les pedimos su aportación.</p>
     <p>Tendrémos una colecta de comida enlínea y pedimos su participación. Se hace pedidos de comida y se los envíe a través de una organización. El primero que le presentamos es <a href="http://bethesdacares.org/">Bethesda Cares</a>. Su envio de comida llegará a la puerta de una familia escogida por orden de esta organización.</p>
-    <img src="images/bethesdacares.png">
+    <img src="/images/bethesdacares.png">
     <p>Les recomendamos esta organización. Ellos sirven todo el condado de Montgomery y en este caso, Bethesda. Haga en qualquiera de los enlaces a continuación para hacer su pedido de comida. Los pedidos se remiten a: Bethesda House, Maria García Ripa, Operation Director, 7728 Woodmont Avenue, Bethesda, Maryland 20814. La comida que piden son:</p>
     <ul>
         <li><a target="_blank" href="https://www.amazon.com/gp/offer-listing/B00AFDB9XO/ref=dp_olp_new_mbc?ie=UTF8&condition=new" rel="noopener">Vienna Sausage</a></li>

--- a/community-service/spanish.html
+++ b/community-service/spanish.html
@@ -1,0 +1,37 @@
+---
+layout: default
+title: Community Service
+stylesheets:
+- community-service
+---
+<article>
+    <h1>Un Apoyo y Voluntarismo a Servicio de la Comunidad</h1>
+    <p>English Now! con nuestro socio, el Centro de Educación Internacional de Washington (CEIW) organizamos actividades para voluntarios durante todo el año.</p>
+    <p>Nuestra meta es unir la comunidad internacional de Washington D.C. con el propósito de proporcionar ayuda a las personas necesitadas. Les invitamos a formar parte de esta misión.</p>
+    <p><strong>Un Servicio Comunitario para Adultos</strong> English Now! y el Centro de Educación promocionamos el voluntarismo entre nuestros residentes internacionales de la área. Esta oportunidad les ofrece la  practica de inglés fuera del salon, el conocimiento de gente nueva, y el intercambio de culturas.</p>
+    <p><strong>Servicios Estudiantiles de Aprendisaje para Adolescents Internacionales</strong> Nuestro Centro de Educación organiza programas que facilitan trabajar las horas de servicio comunitario (“Student Service Learning”, or SSL) requerido por las escuelas públicas y privadas.  Para graduarse del “High School” es necesario cumplir este requisíto. Para conseguir más información sobre los programas de Nuestro Centro en Wahington, véase <a target="_blank" href="files/WCIE - Student Service Learning Programs for International Teens.pdf">aquí</a>.</p>
+    <p><strong>Semanas de Servicios Comunitarios</strong> En el curso de los últimos cinco años hemos organizado dos semanas de servicio comunitario en cada año: una en la primavera y otra en el otoño.  Estas semanas proporcionan oportunidades para participar en actividades de servicio comunitario en pequeños grupos.  Para ver nuestro calendario de actividades del año pasado, véase <a target="_blank" href="files/English Now!-WCIE - Community Service Week - Fall 2019.pdf">aquí</a>.</p>
+    <br>
+    <h2 class="heading">Esta primavera de 2020 será el mes del servicio comunitario</h2>
+    <br>
+    <p>En este momento histórico enfrentamos una pandemia global. Muchas personas estan sufriendo este acontecimiento con muchas necesidades y escasez. Estamos organizando un plan de servicio alimentaria y les pedimos su aportación.</p>
+    <p>Tendrémos una colecta de comida enlínea y pedimos su participación. Se hace pedidos de comida y se los envíe a través de una organización. El primero que le presentamos es <a href="http://bethesdacares.org/">Bethesda Cares</a>. Su envio de comida llegará a la puerta de una familia escogida por orden de esta organización.</p>
+    <img src="images/bethesdacares.png">
+    <p>Les recomendamos esta organización. Ellos sirven todo el condado de Montgomery y en este caso, Bethesda. Haga en qualquiera de los enlaces a continuación para hacer su pedido de comida. Los pedidos se remiten a: Bethesda House, Maria García Ripa, Operation Director, 7728 Woodmont Avenue, Bethesda, Maryland 20814. La comida que piden son:</p>
+    <ul>
+        <li><a target="_blank" href="https://www.amazon.com/gp/offer-listing/B00AFDB9XO/ref=dp_olp_new_mbc?ie=UTF8&condition=new" rel="noopener">Vienna Sausage</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/Kirkland-Signature-Expect-Trail-Snack/dp/B07JQV44GS/ref=sr_1_5?dchild=1&keywords=trail+mix+packets+bulk&qid=1584745843&sr=8-5" rel="noopener">Trail mix</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/AmazonBasics-Compostable-Clamshell-3-Compartment-Containers/dp/B07GYL3672/ref=sr_1_9?keywords=styrofoam+carry+out&amp;qid=1584362087&amp;s=grocery&amp;sr=1-9-catcorr" rel="noopener">Carry-out trays</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/Lipton-Soup-Chicken-Noodle-22-count/dp/B000JCTX5W" rel="noopener">Noodle Soup</a></li>
+        <li><a target="_blank" href="https://www.amazon.com/Ultimate-Healthy-Fitness-Box-Protein/dp/B077R1B7LV/ref=sr_1_17?crid=MAK6DTJYRDGS&amp;dchild=1&amp;keywords=granola+bars+bulk&amp;qid=1584726539&amp;sprefix=granola+bars%2Caps%2C141&amp;sr=8-17" rel="noopener">Granola bars</a></li>
+    </ul>
+    <p><q><a href="https://septemberhousemaj.org/">September House MAJ</a></q> es otra organización excelente y también un socio de nuestro Centro de Educación de Washington.  Apoyan la población japonesa de nuestra región medio-atlántico.  Ayudan a estas familias superar dificultades monetarias, sociales, y emocionales. Ofrecen consultas gratis en japonés que incluyen recursos de asistencia pública y también comestibles.  Esta casa mantiene una lista de artículos preferidos que facilita donar comida japonesa a familias necesitadas.</p>
+    <p>September House MAJ has an Amazon Wish list that enables you to donate Japanese food to families in need. Click here:</p>
+    <p><a href="https://www.amazon.com/hz/wishlist/ls/1ZJA4TNX9M2KF?ref_=wl_share">https://www.amazon.com/hz/wishlist/ls/1ZJA4TNX9M2KF?ref_=wl_share</a></p>
+    <p>If you purchase food on this list, Amazon will send it automatically to September House MAJ.</p>
+    <p><strong>Additional Community Service Month Programs.</strong> We are only starting to feel the impact of the global pandemic. We will do much more to serve the community, and we need your help.</p>
+    <p>Please provide us your name and email address in the form below. We will email you about additional programs to serve the community and bring us together.</p>
+    <p>Thank you very much for your interest in community service. We look forward to serving the community together with you!</p>
+    <iframe id="form" src="https://docs.google.com/forms/d/e/1FAIpQLSc57hU90OEADrj5JYTOKhzGaHr1K1LnTRFXwhJ0pKswEXMd0w/viewform?embedded=true" width="100%" height="729" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+    <img src="images/food-packing-community-service.jpg">
+</article>


### PR DESCRIPTION
- Add Japanese community service page
- Add Spanish community service page
- Add links to new pages in the English one
Future: the language specific content for each page should probably be stored outside of the page's markup.